### PR TITLE
rtl8189fs-mod: Enable monitor mode

### DIFF
--- a/recipes-bsp/rtl8189fs-mod/rtl8189fs-mod/0001-enable-monitor-mode.patch
+++ b/recipes-bsp/rtl8189fs-mod/rtl8189fs-mod/0001-enable-monitor-mode.patch
@@ -1,0 +1,12 @@
+diff -ur git.org/Makefile git/Makefile
+--- git.org/Makefile	2019-03-05 13:33:57.563776906 +0000
++++ git/Makefile	2019-03-05 15:49:01.678369357 +0000
+@@ -72,7 +72,7 @@
+ CONFIG_BR_EXT = y
+ CONFIG_ANTENNA_DIVERSITY = n
+ CONFIG_TDLS = n
+-CONFIG_WIFI_MONITOR = n
++CONFIG_WIFI_MONITOR = y
+ ######################## Wake On Lan ##########################
+ CONFIG_WOWLAN = n
+ CONFIG_GPIO_WAKEUP = n

--- a/recipes-bsp/rtl8189fs-mod/rtl8189fs-mod_git.bb
+++ b/recipes-bsp/rtl8189fs-mod/rtl8189fs-mod_git.bb
@@ -9,6 +9,7 @@ PR = "r0"
 
 SRC_URI = "git://github.com/jwrdegoede/rtl8189ES_linux.git;protocol=https;branch=rtl8189fs \
 	   file://0000-modules-install.patch \
+           file://0001-enable-monitor-mode.patch \
 	   "
 SRCREV = "cddb07311ec03157643c44154498c9f2268fc431"
 


### PR DESCRIPTION
This causes the driver to build to expose monitor mode support.

However in my testing I am not seeing any packets received when
I create a device e.g.

$ iw phy phy0 interface add mon0 type monitor

Signed-off-by: Alex J Lennon <ajlennon@dynamicdevices.co.uk>